### PR TITLE
Handle a wikipedia search with no results

### DIFF
--- a/single_page_hydra/api/clients/wiki_api.py
+++ b/single_page_hydra/api/clients/wiki_api.py
@@ -1,4 +1,4 @@
-from wikipedia import wikipedia, summary, DisambiguationError
+from wikipedia import wikipedia, summary, DisambiguationError, PageError
 
 
 class WikiAPI:
@@ -14,6 +14,9 @@ class WikiAPI:
             titles = e.options
             # let's select the first one and return it
             self.article = wikipedia.page(titles[0])
+
+        except PageError:
+            self.article = wikipedia.page('HTTP 404')
 
         finally:
             title = self.article.title


### PR DESCRIPTION
fixes #19 by redirecting a wikipedia search with no results to the "HTTP 404" wikipedia page.  This is a totally not serious fix, but it is quick and easy.